### PR TITLE
Updated end of line character sequence to CRLF rather than LF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ docs/_build
 /.coverage
 __pycache__
 *.pyc
+*.egg-info
+.idea

--- a/aioftp/client.py
+++ b/aioftp/client.py
@@ -194,7 +194,7 @@ class BaseClient:
         if command:
 
             common.logger.info(add_prefix(command))
-            self.writer.write(str.encode(command + "\n", encoding="utf-8"))
+            self.writer.write(str.encode(command + "\r\n", encoding="utf-8"))
 
         if expected_codes or wait_codes:
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ args = dict(
     name='aioftp',
     version='0.1.8',
     description=('ftp client/server for asyncio'),
-    long_description='\n\n'.join(read('README.rst')),
+    long_description='\n\n'.join(read('readme.rst')),
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+import codecs
+import os
+import re
+import sys
+from setuptools import setup, find_packages, Extension
+from distutils.errors import (CCompilerError, DistutilsExecError,
+                              DistutilsPlatformError)
+from distutils.command.build_ext import build_ext
+
+
+def read(f):
+    return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
+
+args = dict(
+    name='aioftp',
+    version='0.1.8',
+    description=('ftp client/server for asyncio'),
+    long_description='\n\n'.join(read('README.rst')),
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+        'Development Status :: 4 - Beta',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Internet :: File Transfer Protocol (FTP)'],
+    author='pohmelie',
+    author_email='multisosnooley@gmail.com',
+    url='https://github.com/pohmelie/aioftp',
+    license='Apache 2',
+    packages=find_packages(),
+    install_requires=[],
+    include_package_data=True)
+
+setup(**args)   


### PR DESCRIPTION
According to RFC 959 (https://www.ietf.org/rfc/rfc959.txt), the end-of-line sequence for FTP commands should be CRLF and not LF. Most FTP server implementations don't care and support either, but Microsoft's IIS/FTP solution is picky and will return a 451 error response due to the invalid line termination (see https://support.microsoft.com/en-us/kb/2505047).